### PR TITLE
Mugen/contracts

### DIFF
--- a/contracts/manifests/dev/base/abis/contracts/skeleton_smash-actions-7ca74759.json
+++ b/contracts/manifests/dev/base/abis/contracts/skeleton_smash-actions-7ca74759.json
@@ -198,7 +198,7 @@
       },
       {
         "type": "function",
-        "name": "move_player",
+        "name": "move",
         "inputs": [
           {
             "name": "direction",

--- a/contracts/manifests/dev/base/abis/models/skeleton_smash-Room-164aae80.json
+++ b/contracts/manifests/dev/base/abis/models/skeleton_smash-Room-164aae80.json
@@ -387,8 +387,8 @@
         "type": "core::integer::u32"
       },
       {
-        "name": "player_ids",
-        "type": "core::array::Array::<core::starknet::contract_address::ContractAddress>"
+        "name": "run_ids",
+        "type": "core::array::Array::<core::integer::u32>"
       }
     ]
   },

--- a/contracts/manifests/dev/base/abis/models/skeleton_smash-Run-4d03c68b.json
+++ b/contracts/manifests/dev/base/abis/models/skeleton_smash-Run-4d03c68b.json
@@ -367,6 +367,20 @@
     "interface_name": "skeleton_smash::models::player::Irun"
   },
   {
+    "type": "enum",
+    "name": "core::bool",
+    "variants": [
+      {
+        "name": "False",
+        "type": "()"
+      },
+      {
+        "name": "True",
+        "type": "()"
+      }
+    ]
+  },
+  {
     "type": "struct",
     "name": "skeleton_smash::models::player::Run",
     "members": [
@@ -389,6 +403,10 @@
       {
         "name": "move_count",
         "type": "core::integer::u32"
+      },
+      {
+        "name": "is_dead",
+        "type": "core::bool"
       }
     ]
   },

--- a/contracts/manifests/dev/base/contracts/skeleton_smash-actions-7ca74759.toml
+++ b/contracts/manifests/dev/base/contracts/skeleton_smash-actions-7ca74759.toml
@@ -1,6 +1,6 @@
 kind = "DojoContract"
-class_hash = "0x1a8b2934c549ed4efa586303cfe365ba0b0541d3e7d045d8c6de40010251178"
-original_class_hash = "0x1a8b2934c549ed4efa586303cfe365ba0b0541d3e7d045d8c6de40010251178"
+class_hash = "0x62f99bca5959b66286865652724c4e1f0b401f6aa352575e391cca072edcbd8"
+original_class_hash = "0x62f99bca5959b66286865652724c4e1f0b401f6aa352575e391cca072edcbd8"
 base_class_hash = "0x0"
 abi = "manifests/dev/base/abis/contracts/skeleton_smash-actions-7ca74759.json"
 reads = []

--- a/contracts/manifests/dev/base/contracts/skeleton_smash-actions-7ca74759.toml
+++ b/contracts/manifests/dev/base/contracts/skeleton_smash-actions-7ca74759.toml
@@ -1,6 +1,6 @@
 kind = "DojoContract"
-class_hash = "0x54fa6f751a95a6fd2989406a3d1b958ed63c5b96c706ab965dfd6930afc6289"
-original_class_hash = "0x54fa6f751a95a6fd2989406a3d1b958ed63c5b96c706ab965dfd6930afc6289"
+class_hash = "0x29c966a39dc7fc0b23d0f56bdf65784ef0aa6efea721f78c509c20ee1b0e71d"
+original_class_hash = "0x29c966a39dc7fc0b23d0f56bdf65784ef0aa6efea721f78c509c20ee1b0e71d"
 base_class_hash = "0x0"
 abi = "manifests/dev/base/abis/contracts/skeleton_smash-actions-7ca74759.json"
 reads = []

--- a/contracts/manifests/dev/base/contracts/skeleton_smash-actions-7ca74759.toml
+++ b/contracts/manifests/dev/base/contracts/skeleton_smash-actions-7ca74759.toml
@@ -1,6 +1,6 @@
 kind = "DojoContract"
-class_hash = "0x29c966a39dc7fc0b23d0f56bdf65784ef0aa6efea721f78c509c20ee1b0e71d"
-original_class_hash = "0x29c966a39dc7fc0b23d0f56bdf65784ef0aa6efea721f78c509c20ee1b0e71d"
+class_hash = "0x6daae4573e9d0307bec2151463bd5552c9db44a0f36fafc489707b978cc30ec"
+original_class_hash = "0x6daae4573e9d0307bec2151463bd5552c9db44a0f36fafc489707b978cc30ec"
 base_class_hash = "0x0"
 abi = "manifests/dev/base/abis/contracts/skeleton_smash-actions-7ca74759.json"
 reads = []

--- a/contracts/manifests/dev/base/contracts/skeleton_smash-actions-7ca74759.toml
+++ b/contracts/manifests/dev/base/contracts/skeleton_smash-actions-7ca74759.toml
@@ -1,6 +1,6 @@
 kind = "DojoContract"
-class_hash = "0x6daae4573e9d0307bec2151463bd5552c9db44a0f36fafc489707b978cc30ec"
-original_class_hash = "0x6daae4573e9d0307bec2151463bd5552c9db44a0f36fafc489707b978cc30ec"
+class_hash = "0x72c0138e795e80289abcdb1f0284bf15e4f34d18e89b5eeb3d91f011ac3c9c4"
+original_class_hash = "0x72c0138e795e80289abcdb1f0284bf15e4f34d18e89b5eeb3d91f011ac3c9c4"
 base_class_hash = "0x0"
 abi = "manifests/dev/base/abis/contracts/skeleton_smash-actions-7ca74759.json"
 reads = []

--- a/contracts/manifests/dev/base/contracts/skeleton_smash-actions-7ca74759.toml
+++ b/contracts/manifests/dev/base/contracts/skeleton_smash-actions-7ca74759.toml
@@ -1,6 +1,6 @@
 kind = "DojoContract"
-class_hash = "0x72c0138e795e80289abcdb1f0284bf15e4f34d18e89b5eeb3d91f011ac3c9c4"
-original_class_hash = "0x72c0138e795e80289abcdb1f0284bf15e4f34d18e89b5eeb3d91f011ac3c9c4"
+class_hash = "0x1a8b2934c549ed4efa586303cfe365ba0b0541d3e7d045d8c6de40010251178"
+original_class_hash = "0x1a8b2934c549ed4efa586303cfe365ba0b0541d3e7d045d8c6de40010251178"
 base_class_hash = "0x0"
 abi = "manifests/dev/base/abis/contracts/skeleton_smash-actions-7ca74759.json"
 reads = []
@@ -10,7 +10,7 @@ tag = "skeleton_smash-actions"
 systems = [
     "initialize",
     "spawn",
-    "move_player",
+    "move",
     "first_move",
 ]
 manifest_name = "skeleton_smash-actions-7ca74759"

--- a/contracts/manifests/dev/base/models/skeleton_smash-Room-164aae80.toml
+++ b/contracts/manifests/dev/base/models/skeleton_smash-Room-164aae80.toml
@@ -1,6 +1,6 @@
 kind = "DojoModel"
-class_hash = "0x6bf422593059150b234bb6ec3ae46cdbd906fbc2bdcb5464a3a42716a44679"
-original_class_hash = "0x6bf422593059150b234bb6ec3ae46cdbd906fbc2bdcb5464a3a42716a44679"
+class_hash = "0x36873160f677497c6e7571712ec2ab6ea4c602fff8936d5ec7df902f6a1a910"
+original_class_hash = "0x36873160f677497c6e7571712ec2ab6ea4c602fff8936d5ec7df902f6a1a910"
 abi = "manifests/dev/base/abis/models/skeleton_smash-Room-164aae80.json"
 tag = "skeleton_smash-Room"
 qualified_path = "skeleton_smash::models::map::room"
@@ -27,6 +27,6 @@ type = "u32"
 key = false
 
 [[members]]
-name = "player_ids"
-type = "Array<ContractAddress>"
+name = "run_ids"
+type = "Array<u32>"
 key = false

--- a/contracts/manifests/dev/base/models/skeleton_smash-Run-4d03c68b.toml
+++ b/contracts/manifests/dev/base/models/skeleton_smash-Run-4d03c68b.toml
@@ -1,6 +1,6 @@
 kind = "DojoModel"
-class_hash = "0x226564bddad7e9e3a18eb9ee98e36c1688db819da064e237b0fd53549d9594e"
-original_class_hash = "0x226564bddad7e9e3a18eb9ee98e36c1688db819da064e237b0fd53549d9594e"
+class_hash = "0x695817357de69aa5831f65f62c8e3876f7325ec9747fe0bf44865e50ab72424"
+original_class_hash = "0x695817357de69aa5831f65f62c8e3876f7325ec9747fe0bf44865e50ab72424"
 abi = "manifests/dev/base/abis/models/skeleton_smash-Run-4d03c68b.json"
 tag = "skeleton_smash-Run"
 qualified_path = "skeleton_smash::models::player::run"
@@ -29,4 +29,9 @@ key = false
 [[members]]
 name = "move_count"
 type = "u32"
+key = false
+
+[[members]]
+name = "is_dead"
+type = "bool"
 key = false

--- a/contracts/src/consts.cairo
+++ b/contracts/src/consts.cairo
@@ -1,4 +1,4 @@
-pub consts HEIGHT: u32 = 18;
-pub consts WIDTH: u32 = 14;
+pub const HEIGHT: u8 = 18;
+pub const WIDTH: u8 = 14;
 
-pub consts MAX_PLAYERS: u32 = 20;
+pub const MAX_PLAYERS: u32 = 20;

--- a/contracts/src/consts.cairo
+++ b/contracts/src/consts.cairo
@@ -1,0 +1,4 @@
+pub consts HEIGHT: u32 = 18;
+pub consts WIDTH: u32 = 14;
+
+pub consts MAX_PLAYERS: u32 = 20;

--- a/contracts/src/helpers/check_kill.cairo
+++ b/contracts/src/helpers/check_kill.cairo
@@ -27,11 +27,7 @@ fn kill_player(kill_player_position: u8, room_id: u32, world: IWorldDispatcher) 
             player.run_history.append(run_id);
             player.run_id = 0;
 
-            //clear the player from the room bitmap
-            let mut new_room = room;
-            new_room.player_positions = clear_player_bitmap(new_room.player_positions, kill_player_position);
-
-            set!(world, (run, player, new_room));
+            set!(world, (run, player));
             break;
         }
         i += 1;

--- a/contracts/src/helpers/check_kill.cairo
+++ b/contracts/src/helpers/check_kill.cairo
@@ -1,0 +1,39 @@
+use skeleton_smash::helpers::bitmap::{clear_player_bitmap};
+use dojo::world::IWorldDispatcher;
+use skeleton_smash::models::player::{Player, Run, Position};
+use skeleton_smash::models::map::{Room};
+
+fn kill_player(kill_player_position: u8, room_id: u32, world: IWorldDispatcher) {
+
+    let mut room = get!(world, room_id, (Room));
+
+    let mut i = 0;
+    loop {
+        if i == room.run_ids.len() {
+            break;
+        }
+        let run_id = *room.run_ids.at(i);
+        let mut pos = get!(world, run_id, (Position));
+
+        if pos.pos == kill_player_position {
+            let mut run = get!(world, run_id, (Run));
+
+            // Mark the run as dead
+            run.is_dead = true;
+            let contract_address = run.player;
+
+            // Reset the player
+            let mut player = get!(world, contract_address, (Player));
+            player.run_history.append(run_id);
+            player.run_id = 0;
+
+            //clear the player from the room bitmap
+            let mut new_room = room;
+            new_room.player_positions = clear_player_bitmap(new_room.player_positions, kill_player_position);
+
+            set!(world, (run, player, new_room));
+            break;
+        }
+        i += 1;
+    };
+}

--- a/contracts/src/helpers/move.cairo
+++ b/contracts/src/helpers/move.cairo
@@ -1,28 +1,27 @@
 use skeleton_smash::types::direction::Direction;
 use skeleton_smash::helpers::bitmap::{pow2_const};
+use skeleton_smash::consts::{WIDTH, HEIGHT};
 
 // this function will move the player in the room and return the new position
 fn move_player(direction: Direction, map: felt252, player_positions: felt252, mut current_position: u8) -> (u8, bool) {
-    let width = 14;
-    let height = 18;    
     let mut is_exit = false;
     
     // Keep moving until we hit an edge or obstacle
     loop {
         // Check if next position is blocked in map or player_positions
-        if check_out_of_bounds(width, height, current_position, direction) {
+        if check_out_of_bounds(WIDTH, HEIGHT, current_position, direction) {
             break; 
         }
-        if check_blocked(map, width, height, current_position, direction) {
+        if check_blocked(map, WIDTH, HEIGHT, current_position, direction) {
             break; 
         }
-        if check_blocked(player_positions, width, height, current_position, direction) {
+        if check_blocked(player_positions, WIDTH, HEIGHT, current_position, direction) {
             break; 
         }
 
-        current_position = apply_move(direction, current_position, width);
+        current_position = apply_move(direction, current_position, WIDTH);
 
-        if check_exit(width, height, current_position, direction) {
+        if check_exit(WIDTH, HEIGHT, current_position, direction) {
             is_exit = true;
             break;
         }

--- a/contracts/src/lib.cairo
+++ b/contracts/src/lib.cairo
@@ -19,3 +19,5 @@ mod helpers {
 mod types {
     mod direction;
 }
+
+mod consts;

--- a/contracts/src/lib.cairo
+++ b/contracts/src/lib.cairo
@@ -14,6 +14,7 @@ mod helpers {
     mod move;
     mod bitmap;
     mod power;
+    mod check_kill;
 }
 
 mod types {

--- a/contracts/src/models/map.cairo
+++ b/contracts/src/models/map.cairo
@@ -1,6 +1,6 @@
 use starknet::ContractAddress;
 use origami_map::map::{MapTrait};
-use skeleton_smash::consts::{WIDTH, HEIGHT};
+use skeleton_smash::consts::{WIDTH, HEIGHT, MAX_PLAYERS};
 
 #[derive(Drop, Serde, Introspect)]
 #[dojo::model]
@@ -54,7 +54,7 @@ impl RoomImpl of RoomTrait {
         Room { room_id, map: cave_map.grid, player_positions: 0, level, player_ids: ArrayTrait::new() }
     }
     fn is_full(ref self: Room) -> bool {
-        self.player_ids.len() == 5
+        self.player_ids.len() == MAX_PLAYERS
     }
     fn does_room_exist(ref self: Room) -> bool {
         self.map != 0

--- a/contracts/src/models/map.cairo
+++ b/contracts/src/models/map.cairo
@@ -1,5 +1,6 @@
 use starknet::ContractAddress;
 use origami_map::map::{MapTrait};
+use skeleton_smash::consts::{WIDTH, HEIGHT};
 
 #[derive(Drop, Serde, Introspect)]
 #[dojo::model]
@@ -45,7 +46,7 @@ struct Room {
 #[generate_trait]
 impl RoomImpl of RoomTrait {
     fn new(room_id: u32, seed: felt252, level: u32) -> Room {
-        let mut cave_map = MapTrait::new_cave(14, 18, 3, seed);
+        let mut cave_map = MapTrait::new_cave(WIDTH, HEIGHT, 3, seed);
         let position = 245;
         let order = 1;
         cave_map.open_with_corridor(position, order);

--- a/contracts/src/models/map.cairo
+++ b/contracts/src/models/map.cairo
@@ -40,7 +40,7 @@ struct Room {
     map: felt252,
     player_positions: felt252,
     level: u32,
-    player_ids: Array<ContractAddress>, // List of player ids in the room. At 5 players the room is killed
+    run_ids: Array<u32>, // List of player ids in the room. At 5 players the room is killed
 }
 
 #[generate_trait]
@@ -51,26 +51,26 @@ impl RoomImpl of RoomTrait {
         let order = 1;
         cave_map.open_with_corridor(position, order);
         
-        Room { room_id, map: cave_map.grid, player_positions: 0, level, player_ids: ArrayTrait::new() }
+        Room { room_id, map: cave_map.grid, player_positions: 0, level, run_ids: ArrayTrait::new() }
     }
     fn is_full(ref self: Room) -> bool {
-        self.player_ids.len() == MAX_PLAYERS
+        self.run_ids.len() == MAX_PLAYERS
     }
     fn does_room_exist(ref self: Room) -> bool {
         self.map != 0
     }
-    fn add_player(ref self: Room, player_id: ContractAddress) -> Room {
-        let mut player_ids = ArrayTrait::new();
+    fn add_player(ref self: Room, run_id: u32) -> Room {
+        let mut run_ids = ArrayTrait::new();
         let mut i = 0;
         loop {
-            if i == self.player_ids.len() {
+            if i == self.run_ids.len() {
                 break;
             }
-            player_ids.append(*self.player_ids.at(i));
+            run_ids.append(*self.run_ids.at(i));
             i += 1;
         };
-        player_ids.append(player_id);
-        Room { room_id: self.room_id, map: self.map, player_positions: self.player_positions, level: self.level, player_ids }
+        run_ids.append(run_id);
+        Room { room_id: self.room_id, map: self.map, player_positions: self.player_positions, level: self.level, run_ids }
     }
 }
 

--- a/contracts/src/models/player.cairo
+++ b/contracts/src/models/player.cairo
@@ -27,12 +27,13 @@ struct Run {
     room_id: u32,
     level: u32, // current level
     move_count: u32, // remaining moves for that level
+    is_dead: bool, // if true, the player is dead and cannot move
 }
 
 #[generate_trait]
 impl RunImpl of RunTrait {
     fn new(run_id: u32, player: ContractAddress, level: u32, room_id: u32) -> Run {
-        Run { run_id, player, level, room_id, move_count: 0 }
+        Run { run_id, player, level, room_id, move_count: 0, is_dead: false }
     }
 }
 

--- a/contracts/src/systems/actions.cairo
+++ b/contracts/src/systems/actions.cairo
@@ -4,7 +4,7 @@ use skeleton_smash::types::direction::Direction;
 trait IActions {
     fn spawn(ref world: IWorldDispatcher, seed: felt252);
     fn initialize(ref world: IWorldDispatcher);
-    fn move_player(ref world: IWorldDispatcher, direction: Direction, seed: felt252);
+    fn move(ref world: IWorldDispatcher, direction: Direction, seed: felt252);
     fn first_move(ref world: IWorldDispatcher, chosen_column: u8, seed: felt252);
 }
 
@@ -60,7 +60,7 @@ mod actions {
             set!(world, (room_list, room, run, player));
         }
 
-        fn move_player(ref world: IWorldDispatcher, direction: Direction, seed: felt252) {
+        fn move(ref world: IWorldDispatcher, direction: Direction, seed: felt252) {
             let contract_address = get_caller_address();
             let mut player = get!(world, contract_address, (Player));
             let mut room = get!(world, player.run_id, (Room));
@@ -72,7 +72,7 @@ mod actions {
             //update player bitmap and move player
             room.player_positions = clear_player_bitmap(room.player_positions, position.pos);
             let (new_position, is_exit) = move_player(
-                direction, room.map, room.player_positions, position.pos
+                direction, room.map, room.player_positions, position.pos, room.room_id, world
             );
 
             if is_exit {
@@ -126,7 +126,7 @@ mod actions {
 
             // Move has to be North
             let (new_position, is_exit) = move_player(
-                Direction::North, room.map, room.player_positions, position.pos
+                Direction::North, room.map, room.player_positions, position.pos, room.room_id, world
             );
 
             if is_exit {

--- a/contracts/src/systems/actions.cairo
+++ b/contracts/src/systems/actions.cairo
@@ -51,8 +51,8 @@ mod actions {
                 room = RoomTrait::new(room_id, seed, 0);
             }
 
-            room = RoomTrait::add_player(ref room, contract_address);
             let run_id = world.uuid();
+            room = RoomTrait::add_player(ref room, run_id);
             let run = RunTrait::new(run_id, contract_address, 0, room.room_id);
 
             player = PlayerTrait::set_run_id(ref player, run_id);
@@ -91,7 +91,7 @@ mod actions {
                     room_id = *room_list.room_max_id_for_level[new_level];
                     room = RoomTrait::new(room_id, seed, new_level);
                 }
-                room = RoomTrait::add_player(ref room, contract_address);
+                room = RoomTrait::add_player(ref room, run.run_id);
                 run.level = new_level;
                 run.move_count = 0;
                 run.room_id = room_id;
@@ -145,7 +145,7 @@ mod actions {
                     room_id = *room_list.room_max_id_for_level[new_level];
                     room = RoomTrait::new(room_id, seed, new_level);
                 }
-                room = RoomTrait::add_player(ref room, contract_address);
+                room = RoomTrait::add_player(ref room, run.run_id);
                 run.level = new_level;
                 run.move_count = 0;
                 run.room_id = room_id;

--- a/contracts/src/systems/actions.cairo
+++ b/contracts/src/systems/actions.cairo
@@ -1,4 +1,5 @@
 use skeleton_smash::types::direction::Direction;
+use skeleton_smash::consts::{WIDTH, HEIGHT};
 
 #[dojo::interface]
 trait IActions {
@@ -118,9 +119,9 @@ mod actions {
 
             assert(position.pos == 0, 'Invalid position');
 
-            assert(!check_obstacle(room.map, 14, 18, position.pos), 'Wall in the way');
+            assert(!check_obstacle(room.map, WIDTH, HEIGHT, position.pos), 'Wall in the way');
             assert(
-                !check_obstacle(room.player_positions, 14, 18, position.pos), 'Player in the way'
+                !check_obstacle(room.player_positions, WIDTH, HEIGHT, position.pos), 'Player in the way'
             );
 
             // Move has to be North

--- a/contracts/src/systems/actions.cairo
+++ b/contracts/src/systems/actions.cairo
@@ -1,5 +1,4 @@
 use skeleton_smash::types::direction::Direction;
-use skeleton_smash::consts::{WIDTH, HEIGHT};
 
 #[dojo::interface]
 trait IActions {
@@ -18,6 +17,7 @@ mod actions {
     use skeleton_smash::helpers::move::{move_player, check_obstacle, check_out_of_bounds};
     use skeleton_smash::types::direction::Direction;
     use skeleton_smash::helpers::bitmap::{set_player_bitmap, clear_player_bitmap};
+    use skeleton_smash::consts::{WIDTH, HEIGHT};
 
 
     #[abi(embed_v0)]


### PR DESCRIPTION
- replace player ids with run ids in the room struct
 Let's you get the player pos even after he is dead for the wall
- added the kill detection, which resets that players struct and marks the run as dead